### PR TITLE
Fix #49: Addition of purge API

### DIFF
--- a/tidesdb.go
+++ b/tidesdb.go
@@ -298,6 +298,21 @@ func Open(config Config) (*TidesDB, error) {
 	return &TidesDB{db: db}, nil
 }
 
+// Purge purges all in-memory queues and buffers for the entire database.
+func (db *TidesDB) Purge() error {
+	result := C.tidesdb_purge_db(db.db)
+	return errorFromCode(result, "failed to purge database")
+}
+
+// PurgeColumnFamily purges in-memory queues and buffers for a specific column family.
+func (db *TidesDB) PurgeColumnFamily(name string) error {
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+
+	result := C.tidesdb_purge_column_family(db.db, cName)
+	return errorFromCode(result, "failed to purge column family")
+}
+
 // Close closes a TidesDB instance.
 func (db *TidesDB) Close() error {
 	if db == nil || db.db == nil {

--- a/tidesdb_test.go
+++ b/tidesdb_test.go
@@ -29,6 +29,68 @@ import (
 
 const testDBPath = "testdb"
 
+func TestPurge(t *testing.T) {
+	cleanupTestDB(t)
+	defer cleanupTestDB(t)
+
+	config := Config{
+		DBPath:               "testdb",
+		NumFlushThreads:      2,
+		NumCompactionThreads: 2,
+		LogLevel:             LogInfo,
+		BlockCacheSize:       64 * 1024 * 1024,
+		MaxOpenSSTables:      256,
+	}
+
+	db, err := Open(config)
+	if err != nil {
+		t.Fatalf("Failed to open database: %v", err)
+	}
+	defer db.Close()
+
+	cfConfig := DefaultColumnFamilyConfig()
+	err = db.CreateColumnFamily("test_cf", cfConfig)
+	if err != nil {
+		t.Fatalf("Failed to create column family: %v", err)
+	}
+
+	err = db.Purge()
+	if err != nil {
+		t.Fatalf("Failed to purge database: %v", err)
+	}
+}
+
+func TestPurgeColumnFamily(t *testing.T) {
+	cleanupTestDB(t)
+	defer cleanupTestDB(t)
+
+	config := Config{
+		DBPath:               "testdb",
+		NumFlushThreads:      2,
+		NumCompactionThreads: 2,
+		LogLevel:             LogInfo,
+		BlockCacheSize:       64 * 1024 * 1024,
+		MaxOpenSSTables:      256,
+	}
+
+	db, err := Open(config)
+	if err != nil {
+		t.Fatalf("Failed to open database: %v", err)
+	}
+	defer db.Close()
+
+	cfConfig := DefaultColumnFamilyConfig()
+	err = db.CreateColumnFamily("test_cf", cfConfig)
+	if err != nil {
+		t.Fatalf("Failed to create column family: %v", err)
+	}
+
+	err = db.PurgeColumnFamily("test_cf")
+	if err != nil {
+		t.Fatalf("Failed to purge column family: %v", err)
+	}
+}
+
 func cleanupTestDB(t *testing.T) {
 	os.RemoveAll(testDBPath)
 }


### PR DESCRIPTION
## Summary

Add Go bindings for the new TidesDB v8.7.0 purge API methods: purge database and purge column family.

## Approach

Add two new methods to the TidesDB Go binding: (1) `Purge()` which calls the C function `tidesdb_purge_db` to purge all in-memory queues and buffers for the entire database, and (2) `PurgeColumnFamily(name string)` which calls `tidesdb_purge_column_family` to purge in-memory queues and buffers for a specific column family. Both methods should follow the existing pattern in tidesdb.go of calling the underlying C API via cgo, checking the returned error, and wrapping it in a Go error. Tests should be added in tidesdb_test.go to verify both purge methods work correctly.

## Files Changed

- `tidesdb.go`
- `tidesdb_test.go`

## Related Issue

Fixes #49

## Testing

No tests were added with this change. Happy to add them if needed.
