### PR TITLE
iss #55 #56 retire unused objecttargetfilesize cf config field and ad…

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,3 @@ BSD (Zstandard)
 ## Contributing
 
 Contributions are welcome! Please feel free to submit a Pull Request.
-
-## Support
-
-For issues, questions, or discussions
-- GitHub Issues https://github.com/tidesdb/tidesdb-go/issues
-- Discord Community https://discord.gg/tWEmjR66cy

--- a/commit_hook.go
+++ b/commit_hook.go
@@ -17,8 +17,9 @@
 package tidesdb_go
 
 /*
+#include <stdint.h>
 #include <tidesdb/db.h>
-extern int set_commit_hook_bridge(tidesdb_column_family_t *cf, void *ctx);
+extern int set_commit_hook_bridge(tidesdb_column_family_t *cf, uintptr_t ctx);
 */
 import "C"
 import (
@@ -71,7 +72,7 @@ func (cf *ColumnFamily) SetCommitHook(fn CommitHookFunc) error {
 	commitHookCFMap[cfKey] = id
 	commitHookMu.Unlock()
 
-	result := C.set_commit_hook_bridge(cf.cf, unsafe.Pointer(id))
+	result := C.set_commit_hook_bridge(cf.cf, C.uintptr_t(id))
 	return errorFromCode(result, "failed to set commit hook")
 }
 

--- a/commit_hook_bridge.c
+++ b/commit_hook_bridge.c
@@ -14,6 +14,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+#include <stdint.h>
 #include <tidesdb/db.h>
 #include "_cgo_export.h"
 
@@ -23,7 +24,8 @@ int commit_hook_bridge(const tidesdb_commit_op_t *ops, int num_ops,
     return goCommitHookCallback((tidesdb_commit_op_t *)ops, num_ops, commit_seq, ctx);
 }
 
-int set_commit_hook_bridge(tidesdb_column_family_t *cf, void *ctx)
+int set_commit_hook_bridge(tidesdb_column_family_t *cf, uintptr_t ctx)
 {
-    return tidesdb_cf_set_commit_hook(cf, (tidesdb_commit_hook_fn)commit_hook_bridge, ctx);
+    return tidesdb_cf_set_commit_hook(cf, (tidesdb_commit_hook_fn)commit_hook_bridge,
+                                      (void *)ctx);
 }

--- a/tidesdb.go
+++ b/tidesdb.go
@@ -246,7 +246,6 @@ type ColumnFamilyConfig struct {
 	L1FileCountTrigger       int
 	L0QueueStallThreshold    int
 	UseBtree                 int
-	ObjectTargetFileSize     uint64
 	ObjectLazyCompaction     int
 	ObjectPrefetchCompaction int
 }
@@ -407,7 +406,6 @@ func DefaultColumnFamilyConfig() ColumnFamilyConfig {
 		L1FileCountTrigger:    int(cConfig.l1_file_count_trigger),
 		L0QueueStallThreshold:    int(cConfig.l0_queue_stall_threshold),
 		UseBtree:                 int(cConfig.use_btree),
-		ObjectTargetFileSize:     uint64(cConfig.object_target_file_size),
 		ObjectLazyCompaction:     int(cConfig.object_lazy_compaction),
 		ObjectPrefetchCompaction: int(cConfig.object_prefetch_compaction),
 	}
@@ -556,7 +554,6 @@ func (db *TidesDB) CreateColumnFamily(name string, config ColumnFamilyConfig) er
 		l1_file_count_trigger:    C.int(config.L1FileCountTrigger),
 		l0_queue_stall_threshold:     C.int(config.L0QueueStallThreshold),
 		use_btree:                    C.int(config.UseBtree),
-		object_target_file_size:      C.size_t(config.ObjectTargetFileSize),
 		object_lazy_compaction:       C.int(config.ObjectLazyCompaction),
 		object_prefetch_compaction:   C.int(config.ObjectPrefetchCompaction),
 	}
@@ -732,7 +729,6 @@ func (cf *ColumnFamily) GetStats() (*Stats, error) {
 			L1FileCountTrigger:    int(cStats.config.l1_file_count_trigger),
 			L0QueueStallThreshold:    int(cStats.config.l0_queue_stall_threshold),
 			UseBtree:                 int(cStats.config.use_btree),
-			ObjectTargetFileSize:     uint64(cStats.config.object_target_file_size),
 			ObjectLazyCompaction:     int(cStats.config.object_lazy_compaction),
 			ObjectPrefetchCompaction: int(cStats.config.object_prefetch_compaction),
 		}
@@ -761,9 +757,9 @@ func (db *TidesDB) GetCacheStats() (*CacheStats, error) {
 }
 
 // RangeCost estimates the computational cost of iterating between two keys in a column family.
-// The returned value is an opaque double — meaningful only for comparison with other values
+// The returned value is an opaque double - meaningful only for comparison with other values
 // from the same function. It uses only in-memory metadata and performs no disk I/O.
-// Key order does not matter — the function normalizes the range internally.
+// Key order does not matter - the function normalizes the range internally.
 func (cf *ColumnFamily) RangeCost(keyA, keyB []byte) (float64, error) {
 	var cKeyA, cKeyB *C.uint8_t
 	if len(keyA) > 0 {
@@ -901,7 +897,6 @@ func (cf *ColumnFamily) UpdateRuntimeConfig(config ColumnFamilyConfig, persistTo
 		l1_file_count_trigger:    C.int(config.L1FileCountTrigger),
 		l0_queue_stall_threshold:     C.int(config.L0QueueStallThreshold),
 		use_btree:                    C.int(config.UseBtree),
-		object_target_file_size:      C.size_t(config.ObjectTargetFileSize),
 		object_lazy_compaction:       C.int(config.ObjectLazyCompaction),
 		object_prefetch_compaction:   C.int(config.ObjectPrefetchCompaction),
 	}
@@ -1025,6 +1020,27 @@ func (txn *Transaction) Delete(cf *ColumnFamily, key []byte) error {
 
 	result := C.tidesdb_txn_delete(txn.txn, cf.cf, cKey, C.size_t(len(key)))
 	return errorFromCode(result, "failed to delete key")
+}
+
+// SingleDelete writes a tombstone carrying a caller-provided promise that the key
+// has been put at most once since its previous single-delete (or since the start
+// of history). This lets compaction drop the put and tombstone together as soon
+// as both appear in the same merge input, rather than carrying the tombstone
+// forward to the largest active level. Read semantics match Delete.
+//
+// The engine does not verify the promise at runtime; violating it can leave
+// older puts visible and is a bug in the caller. Use only for insert-once-then-
+// delete patterns (classic insert benchmarks, secondary indexes on never-updated
+// columns, log tables with scheduled purges). Not safe for repeated updates to
+// the same key - when in doubt, prefer Delete.
+func (txn *Transaction) SingleDelete(cf *ColumnFamily, key []byte) error {
+	var cKey *C.uint8_t
+	if len(key) > 0 {
+		cKey = (*C.uint8_t)(unsafe.Pointer(&key[0]))
+	}
+
+	result := C.tidesdb_txn_single_delete(txn.txn, cf.cf, cKey, C.size_t(len(key)))
+	return errorFromCode(result, "failed to single-delete key")
 }
 
 // Commit commits the transaction.
@@ -1239,7 +1255,6 @@ func CfConfigLoadFromIni(iniFile, sectionName string) (*ColumnFamilyConfig, erro
 		L1FileCountTrigger:       int(cConfig.l1_file_count_trigger),
 		L0QueueStallThreshold:    int(cConfig.l0_queue_stall_threshold),
 		UseBtree:                 int(cConfig.use_btree),
-		ObjectTargetFileSize:     uint64(cConfig.object_target_file_size),
 		ObjectLazyCompaction:     int(cConfig.object_lazy_compaction),
 		ObjectPrefetchCompaction: int(cConfig.object_prefetch_compaction),
 	}, nil
@@ -1273,7 +1288,6 @@ func CfConfigSaveToIni(iniFile, sectionName string, config ColumnFamilyConfig) e
 		l1_file_count_trigger:      C.int(config.L1FileCountTrigger),
 		l0_queue_stall_threshold:   C.int(config.L0QueueStallThreshold),
 		use_btree:                  C.int(config.UseBtree),
-		object_target_file_size:    C.size_t(config.ObjectTargetFileSize),
 		object_lazy_compaction:     C.int(config.ObjectLazyCompaction),
 		object_prefetch_compaction: C.int(config.ObjectPrefetchCompaction),
 	}

--- a/tidesdb_test.go
+++ b/tidesdb_test.go
@@ -254,6 +254,98 @@ func TestTransactionPutGetDelete(t *testing.T) {
 	}
 }
 
+func TestTransactionSingleDelete(t *testing.T) {
+	cleanupTestDB(t)
+	defer cleanupTestDB(t)
+
+	config := Config{
+		DBPath:               "testdb",
+		NumFlushThreads:      2,
+		NumCompactionThreads: 2,
+		LogLevel:             LogInfo,
+		BlockCacheSize:       64 * 1024 * 1024,
+		MaxOpenSSTables:      256,
+	}
+
+	db, err := Open(config)
+	if err != nil {
+		t.Fatalf("Failed to open database: %v", err)
+	}
+	defer db.Close()
+
+	cfConfig := DefaultColumnFamilyConfig()
+	err = db.CreateColumnFamily("test_cf", cfConfig)
+	if err != nil {
+		t.Fatalf("Failed to create column family: %v", err)
+	}
+
+	cf, err := db.GetColumnFamily("test_cf")
+	if err != nil {
+		t.Fatalf("Failed to get column family: %v", err)
+	}
+
+	key := []byte("single_delete_key")
+	value := []byte("insert_once")
+
+	putTxn, err := db.BeginTxn()
+	if err != nil {
+		t.Fatalf("Failed to begin put transaction: %v", err)
+	}
+
+	err = putTxn.Put(cf, key, value, -1)
+	if err != nil {
+		t.Fatalf("Failed to put key-value pair: %v", err)
+	}
+
+	err = putTxn.Commit()
+	if err != nil {
+		t.Fatalf("Failed to commit put transaction: %v", err)
+	}
+	putTxn.Free()
+
+	readTxn, err := db.BeginTxn()
+	if err != nil {
+		t.Fatalf("Failed to begin read transaction: %v", err)
+	}
+
+	gotValue, err := readTxn.Get(cf, key)
+	if err != nil {
+		t.Fatalf("Failed to get value: %v", err)
+	}
+	readTxn.Free()
+
+	if string(gotValue) != string(value) {
+		t.Fatalf("Expected value %s, got %s", value, gotValue)
+	}
+
+	singleDeleteTxn, err := db.BeginTxn()
+	if err != nil {
+		t.Fatalf("Failed to begin single-delete transaction: %v", err)
+	}
+
+	err = singleDeleteTxn.SingleDelete(cf, key)
+	if err != nil {
+		t.Fatalf("Failed to single-delete key: %v", err)
+	}
+
+	err = singleDeleteTxn.Commit()
+	if err != nil {
+		t.Fatalf("Failed to commit single-delete transaction: %v", err)
+	}
+	singleDeleteTxn.Free()
+
+	verifyTxn, err := db.BeginTxn()
+	if err != nil {
+		t.Fatalf("Failed to begin verify transaction: %v", err)
+	}
+	defer verifyTxn.Free()
+
+	_, err = verifyTxn.Get(cf, key)
+	if err == nil {
+		t.Fatalf("Expected key to be single-deleted but it still exists")
+	}
+}
+
 func TestTransactionWithTTL(t *testing.T) {
 	cleanupTestDB(t)
 	defer cleanupTestDB(t)
@@ -2491,7 +2583,7 @@ func TestCommitHookClear(t *testing.T) {
 		t.Fatalf("Failed to clear commit hook: %v", err)
 	}
 
-	// Commit again — hook should NOT fire
+	// Commit again - hook should NOT fire
 	txn2, err := db.BeginTxn()
 	if err != nil {
 		t.Fatalf("Failed to begin transaction: %v", err)
@@ -3596,7 +3688,6 @@ func TestColumnFamilyConfigObjectStoreFields(t *testing.T) {
 	defer db.Close()
 
 	cfConfig := DefaultColumnFamilyConfig()
-	cfConfig.ObjectTargetFileSize = 128 * 1024 * 1024 // 128MB
 	cfConfig.ObjectLazyCompaction = 1
 	cfConfig.ObjectPrefetchCompaction = 0
 
@@ -3619,7 +3710,6 @@ func TestColumnFamilyConfigObjectStoreFields(t *testing.T) {
 		t.Fatalf("Expected config in stats, got nil")
 	}
 
-	t.Logf("ObjectTargetFileSize: %d", stats.Config.ObjectTargetFileSize)
 	t.Logf("ObjectLazyCompaction: %d", stats.Config.ObjectLazyCompaction)
 	t.Logf("ObjectPrefetchCompaction: %d", stats.Config.ObjectPrefetchCompaction)
 


### PR DESCRIPTION
…d singledelete transaction binding; correct vet warning regarding commit hook brige utilizing uintptr_t on go side, also update read me removing useless section on support