### PR TITLE
add missing db.h abi bindings to go ffi library

### DIFF
--- a/objstore_s3.go
+++ b/objstore_s3.go
@@ -1,0 +1,143 @@
+// Package tidesdb_go
+// Copyright (C) TidesDB
+//
+// Original Author: Alex Gaetano Padula
+//
+// Licensed under the Mozilla Public License, v. 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	https://www.mozilla.org/en-US/MPL/2.0/
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build tidesdb_s3
+
+// The S3 object store connector is only available when the TidesDB C library was
+// built with TIDESDB_WITH_S3=ON. Because the tidesdb_objstore_s3_* symbols are
+// otherwise unresolved at link time, these bindings are gated behind the
+// "tidesdb_s3" build tag. Build or test with: go build -tags tidesdb_s3 ./...
+package tidesdb_go
+
+/*
+#cgo LDFLAGS: -ltidesdb
+#include <tidesdb/db.h>
+#include <stdlib.h>
+*/
+import "C"
+import (
+	"fmt"
+	"unsafe"
+)
+
+// S3Config is the full configuration for an S3-compatible object store connector,
+// including TLS and multipart tuning that the positional ObjStoreS3Create cannot
+// express. The zero value is secure (TLS verification on, no custom CA) and uses
+// the library's built-in multipart sizes.
+type S3Config struct {
+	Endpoint              string // S3 endpoint (required), e.g. "s3.amazonaws.com" or "minio.local:9000"
+	Bucket                string // bucket name (required)
+	Prefix                string // key prefix (e.g. "production/db1/"), may be empty
+	AccessKey             string // AWS access key ID (required)
+	SecretKey             string // AWS secret access key (required)
+	Region                string // AWS region (e.g. "us-east-1"), empty for the default / MinIO
+	UseSSL                bool   // true for HTTPS, false for HTTP
+	UsePathStyle          bool   // true for path-style URLs (MinIO), false for virtual-hosted (AWS)
+	TLSCAPath             string // custom CA bundle file path, empty for the system bundle
+	TLSInsecureSkipVerify bool   // true disables TLS peer+host verification (test only, insecure)
+	MultipartThreshold    uint64 // object size at/above which multipart upload is used; 0 = default
+	MultipartPartSize     uint64 // multipart chunk size in bytes; 0 = default
+}
+
+// ObjStoreS3Create creates an S3-compatible object store connector (AWS S3, MinIO, etc.)
+// using positional parameters with secure defaults. For TLS and multipart tuning use
+// ObjStoreS3CreateConfig.
+//
+// The TidesDB C library must have been built with TIDESDB_WITH_S3=ON; otherwise this
+// package will not link. Build with the "tidesdb_s3" tag to enable these bindings.
+func ObjStoreS3Create(endpoint, bucket, prefix, accessKey, secretKey, region string, useSSL, usePathStyle bool) (*ObjStore, error) {
+	cEndpoint := C.CString(endpoint)
+	defer C.free(unsafe.Pointer(cEndpoint))
+	cBucket := C.CString(bucket)
+	defer C.free(unsafe.Pointer(cBucket))
+	cAccessKey := C.CString(accessKey)
+	defer C.free(unsafe.Pointer(cAccessKey))
+	cSecretKey := C.CString(secretKey)
+	defer C.free(unsafe.Pointer(cSecretKey))
+
+	var cPrefix *C.char
+	if prefix != "" {
+		cPrefix = C.CString(prefix)
+		defer C.free(unsafe.Pointer(cPrefix))
+	}
+	var cRegion *C.char
+	if region != "" {
+		cRegion = C.CString(region)
+		defer C.free(unsafe.Pointer(cRegion))
+	}
+
+	store := C.tidesdb_objstore_s3_create(cEndpoint, cBucket, cPrefix, cAccessKey, cSecretKey,
+		cRegion, boolToInt(useSSL), boolToInt(usePathStyle))
+	if store == nil {
+		return nil, fmt.Errorf("failed to create S3 object store for bucket %q at %s", bucket, endpoint)
+	}
+
+	return &ObjStore{store: store}, nil
+}
+
+// ObjStoreS3CreateConfig creates an S3-compatible connector from a full configuration
+// struct (TLS + multipart). ObjStoreS3Create is a thin wrapper over this with
+// secure/default settings.
+//
+// The TidesDB C library must have been built with TIDESDB_WITH_S3=ON; otherwise this
+// package will not link. Build with the "tidesdb_s3" tag to enable these bindings.
+func ObjStoreS3CreateConfig(config S3Config) (*ObjStore, error) {
+	cEndpoint := C.CString(config.Endpoint)
+	defer C.free(unsafe.Pointer(cEndpoint))
+	cBucket := C.CString(config.Bucket)
+	defer C.free(unsafe.Pointer(cBucket))
+	cAccessKey := C.CString(config.AccessKey)
+	defer C.free(unsafe.Pointer(cAccessKey))
+	cSecretKey := C.CString(config.SecretKey)
+	defer C.free(unsafe.Pointer(cSecretKey))
+
+	var cPrefix, cRegion, cTLSCAPath *C.char
+	if config.Prefix != "" {
+		cPrefix = C.CString(config.Prefix)
+		defer C.free(unsafe.Pointer(cPrefix))
+	}
+	if config.Region != "" {
+		cRegion = C.CString(config.Region)
+		defer C.free(unsafe.Pointer(cRegion))
+	}
+	if config.TLSCAPath != "" {
+		cTLSCAPath = C.CString(config.TLSCAPath)
+		defer C.free(unsafe.Pointer(cTLSCAPath))
+	}
+
+	cConfig := C.tidesdb_objstore_s3_config_t{
+		endpoint:                 cEndpoint,
+		bucket:                   cBucket,
+		prefix:                   cPrefix,
+		access_key:               cAccessKey,
+		secret_key:               cSecretKey,
+		region:                   cRegion,
+		use_ssl:                  boolToInt(config.UseSSL),
+		use_path_style:           boolToInt(config.UsePathStyle),
+		tls_ca_path:              cTLSCAPath,
+		tls_insecure_skip_verify: boolToInt(config.TLSInsecureSkipVerify),
+		multipart_threshold:      C.size_t(config.MultipartThreshold),
+		multipart_part_size:      C.size_t(config.MultipartPartSize),
+	}
+
+	store := C.tidesdb_objstore_s3_create_config(&cConfig)
+	if store == nil {
+		return nil, fmt.Errorf("failed to create S3 object store for bucket %q at %s", config.Bucket, config.Endpoint)
+	}
+
+	return &ObjStore{store: store}, nil
+}

--- a/objstore_s3_test.go
+++ b/objstore_s3_test.go
@@ -1,0 +1,83 @@
+// Package tidesdb_go
+// Copyright (C) TidesDB
+//
+// Original Author: Alex Gaetano Padula
+//
+// Licensed under the Mozilla Public License, v. 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	https://www.mozilla.org/en-US/MPL/2.0/
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build tidesdb_s3
+
+// These tests are compiled and run only with the "tidesdb_s3" build tag against a
+// TidesDB C library built with TIDESDB_WITH_S3=ON. Point them at a reachable
+// S3-compatible endpoint (e.g. a local MinIO) via the TIDESDB_S3_* env vars, or
+// they are skipped. Run with: go test -tags tidesdb_s3 -run TestObjStoreS3 ./...
+package tidesdb_go
+
+import (
+	"os"
+	"testing"
+)
+
+func TestObjStoreS3Create(t *testing.T) {
+	endpoint := os.Getenv("TIDESDB_S3_ENDPOINT")
+	bucket := os.Getenv("TIDESDB_S3_BUCKET")
+	if endpoint == "" || bucket == "" {
+		t.Skip("set TIDESDB_S3_ENDPOINT and TIDESDB_S3_BUCKET to run the S3 connector test")
+	}
+
+	store, err := ObjStoreS3Create(
+		endpoint,
+		bucket,
+		os.Getenv("TIDESDB_S3_PREFIX"),
+		os.Getenv("TIDESDB_S3_ACCESS_KEY"),
+		os.Getenv("TIDESDB_S3_SECRET_KEY"),
+		os.Getenv("TIDESDB_S3_REGION"),
+		os.Getenv("TIDESDB_S3_USE_SSL") == "1",
+		os.Getenv("TIDESDB_S3_USE_PATH_STYLE") == "1",
+	)
+	if err != nil {
+		t.Fatalf("ObjStoreS3Create failed: %v", err)
+	}
+	if store == nil || store.store == nil {
+		t.Fatalf("Expected a non-nil S3 connector handle")
+	}
+	t.Logf("Created S3 connector for bucket %q at %s", bucket, endpoint)
+}
+
+func TestObjStoreS3CreateConfig(t *testing.T) {
+	endpoint := os.Getenv("TIDESDB_S3_ENDPOINT")
+	bucket := os.Getenv("TIDESDB_S3_BUCKET")
+	if endpoint == "" || bucket == "" {
+		t.Skip("set TIDESDB_S3_ENDPOINT and TIDESDB_S3_BUCKET to run the S3 connector test")
+	}
+
+	cfg := S3Config{
+		Endpoint:     endpoint,
+		Bucket:       bucket,
+		Prefix:       os.Getenv("TIDESDB_S3_PREFIX"),
+		AccessKey:    os.Getenv("TIDESDB_S3_ACCESS_KEY"),
+		SecretKey:    os.Getenv("TIDESDB_S3_SECRET_KEY"),
+		Region:       os.Getenv("TIDESDB_S3_REGION"),
+		UseSSL:       os.Getenv("TIDESDB_S3_USE_SSL") == "1",
+		UsePathStyle: os.Getenv("TIDESDB_S3_USE_PATH_STYLE") == "1",
+	}
+
+	store, err := ObjStoreS3CreateConfig(cfg)
+	if err != nil {
+		t.Fatalf("ObjStoreS3CreateConfig failed: %v", err)
+	}
+	if store == nil || store.store == nil {
+		t.Fatalf("Expected a non-nil S3 connector handle")
+	}
+	t.Logf("Created S3 connector (config form) for bucket %q at %s", bucket, endpoint)
+}

--- a/tidesdb.go
+++ b/tidesdb.go
@@ -92,6 +92,29 @@ const (
 	ErrUnknown     = C.TDB_ERR_UNKNOWN
 	ErrLocked      = C.TDB_ERR_LOCKED
 	ErrReadonly    = C.TDB_ERR_READONLY
+	ErrBusy        = C.TDB_ERR_BUSY
+)
+
+// Built-in comparator names. Each is auto-registered when a database is opened,
+// so any of these may be assigned to ColumnFamilyConfig.ComparatorName without
+// first calling RegisterComparator.
+const (
+	// ComparatorMemcmp orders keys by unsigned byte-wise comparison (the default).
+	ComparatorMemcmp = "memcmp"
+	// ComparatorLexicographic orders keys lexicographically.
+	ComparatorLexicographic = "lexicographic"
+	// ComparatorUint64 interprets each 8-byte key as a uint64 in host byte order
+	// (little-endian on most platforms). Keys whose length is not 8 fall back to
+	// memcmp ordering. Encode keys with encoding/binary.NativeEndian to match.
+	ComparatorUint64 = "uint64"
+	// ComparatorInt64 interprets each 8-byte key as an int64 in host byte order
+	// (little-endian on most platforms). Keys whose length is not 8 fall back to
+	// memcmp ordering. Encode keys with encoding/binary.NativeEndian to match.
+	ComparatorInt64 = "int64"
+	// ComparatorReverse orders keys by reverse byte-wise comparison (descending).
+	ComparatorReverse = "reverse"
+	// ComparatorCaseInsensitive orders keys by case-insensitive byte-wise comparison.
+	ComparatorCaseInsensitive = "case_insensitive"
 )
 
 // ObjStoreBackend identifies the object store backend in use.
@@ -181,6 +204,18 @@ func Finalize() {
 	C.tidesdb_finalize()
 }
 
+// RaiseOpenFileLimit raises this process's open-file ceiling toward desired
+// descriptors so a database can keep more sstables open. Because TidesDB sizes
+// MaxOpenSSTables to fit this at open time, call it BEFORE Open. This is an
+// explicit, opt-in operator action; TidesDB never raises the limit itself.
+//
+// A desired value <= 0 just reports the current ceiling without changing it.
+// A failed or partial raise is non-fatal. The returned value is the open-file
+// ceiling in effect after the attempt.
+func RaiseOpenFileLimit(desired int64) int64 {
+	return int64(C.tidesdb_raise_open_file_limit(C.long(desired)))
+}
+
 // TidesDB is a TidesDB instance.
 type TidesDB struct {
 	db *C.tidesdb_t
@@ -219,38 +254,40 @@ type Config struct {
 	UnifiedMemtableSyncMode            SyncMode
 	UnifiedMemtableSyncInterval        uint64
 	MaxConcurrentFlushes               int
+	FinishCompactionsOnClose           bool
 	ObjectStore                        *ObjStore
 	ObjectStoreConfig                  *ObjStoreConfig
 }
 
 // ColumnFamilyConfig is the configuration for a column family.
 type ColumnFamilyConfig struct {
-	Name                        string
-	WriteBufferSize             uint64
-	LevelSizeRatio              uint64
-	MinLevels                   int
-	DividingLevelOffset         int
-	KlogValueThreshold          uint64
-	CompressionAlgorithm        CompressionAlgorithm
-	EnableBloomFilter           bool
-	BloomFPR                    float64
-	EnableBlockIndexes          bool
-	IndexSampleRatio            int
-	BlockIndexPrefixLen         int
-	SyncMode                    SyncMode
-	SyncIntervalUs              uint64
-	ComparatorName              string
-	SkipListMaxLevel            int
-	SkipListProbability         float32
-	DefaultIsolationLevel       IsolationLevel
-	MinDiskSpace                uint64
-	L1FileCountTrigger          int
-	L0QueueStallThreshold       int
-	TombstoneDensityTrigger     float64
-	TombstoneDensityMinEntries  uint64
-	UseBtree                    int
-	ObjectLazyCompaction        int
-	ObjectPrefetchCompaction    int
+	Name                       string
+	WriteBufferSize            uint64
+	LevelSizeRatio             uint64
+	MinLevels                  int
+	DividingLevelOffset        int
+	KlogValueThreshold         uint64
+	CompressionAlgorithm       CompressionAlgorithm
+	EnableBloomFilter          bool
+	BloomFPR                   float64
+	EnableBlockIndexes         bool
+	IndexSampleRatio           int
+	BlockIndexPrefixLen        int
+	SyncMode                   SyncMode
+	SyncIntervalUs             uint64
+	ComparatorName             string
+	ComparatorCtxStr           string
+	SkipListMaxLevel           int
+	SkipListProbability        float32
+	DefaultIsolationLevel      IsolationLevel
+	MinDiskSpace               uint64
+	L1FileCountTrigger         int
+	L0QueueStallThreshold      int
+	TombstoneDensityTrigger    float64
+	TombstoneDensityMinEntries uint64
+	UseBtree                   int
+	ObjectLazyCompaction       int
+	ObjectPrefetchCompaction   int
 }
 
 // Stats is statistics about a column family.
@@ -276,6 +313,17 @@ type Stats struct {
 	LevelTombstoneCounts []uint64
 	MaxSSTDensity        float64
 	MaxSSTDensityLevel   int
+	// Write-amplification counters (lifetime since open, on-disk framed bytes).
+	// Divide the write totals by UserBytesWritten for this CF's write amplification.
+	// WalBytesWritten is zero in unified mode; the shared WAL volume is reported
+	// db-wide via DbStats.UwalBytesWritten. The *Count fields count output sstables.
+	WalBytesWritten        uint64
+	FlushBytesWritten      uint64
+	CompactionBytesWritten uint64
+	CompactionBytesRead    uint64
+	UserBytesWritten       uint64
+	FlushCount             uint64
+	CompactionCount        uint64
 }
 
 // CacheStats is statistics about the block cache.
@@ -291,37 +339,50 @@ type CacheStats struct {
 
 // DbStats is aggregate statistics across the entire database instance.
 type DbStats struct {
-	NumColumnFamilies       int
-	TotalMemory             uint64
-	AvailableMemory         uint64
-	ResolvedMemoryLimit     uint64
-	MemoryPressureLevel     int
-	FlushPendingCount       int
-	TotalMemtableBytes      int64
-	TotalImmutableCount     int
-	TotalSstableCount       int
-	TotalDataSizeBytes      uint64
-	NumOpenSstables         int
-	GlobalSeq               uint64
-	TxnMemoryBytes          int64
-	CompactionQueueSize     uint64
-	FlushQueueSize          uint64
-	UnifiedMemtableEnabled  bool
-	UnifiedMemtableBytes    int64
-	UnifiedImmutableCount   int
-	UnifiedIsFlushing       bool
-	UnifiedNextCFIndex      uint32
-	UnifiedWalGeneration    uint64
-	ObjectStoreEnabled      bool
-	ObjectStoreConnector    string
-	LocalCacheBytesUsed     uint64
-	LocalCacheBytesMax      uint64
-	LocalCacheNumFiles      int
-	LastUploadedGeneration  uint64
-	UploadQueueDepth        uint64
-	TotalUploads            uint64
-	TotalUploadFailures     uint64
-	ReplicaMode             bool
+	NumColumnFamilies      int
+	TotalMemory            uint64
+	AvailableMemory        uint64
+	ResolvedMemoryLimit    uint64
+	MemoryPressureLevel    int
+	FlushPendingCount      int
+	TotalMemtableBytes     int64
+	TotalImmutableCount    int
+	TotalSstableCount      int
+	TotalDataSizeBytes     uint64
+	NumOpenSstables        int
+	GlobalSeq              uint64
+	TxnMemoryBytes         int64
+	CompactionQueueSize    uint64
+	FlushQueueSize         uint64
+	UnifiedMemtableEnabled bool
+	UnifiedMemtableBytes   int64
+	UnifiedImmutableCount  int
+	UnifiedIsFlushing      bool
+	UnifiedNextCFIndex     uint32
+	UnifiedWalGeneration   uint64
+	ObjectStoreEnabled     bool
+	ObjectStoreConnector   string
+	LocalCacheBytesUsed    uint64
+	LocalCacheBytesMax     uint64
+	LocalCacheNumFiles     int
+	LastUploadedGeneration uint64
+	UploadQueueDepth       uint64
+	TotalUploads           uint64
+	TotalUploadFailures    uint64
+	ReplicaMode            bool
+	// Write-amplification counters (lifetime since open, on-disk framed bytes).
+	// UwalBytesWritten is the shared unified WAL volume (zero when unified mode is
+	// off); the remaining fields are summed across all column families. db-wide
+	// write amplification = (uwal + wal + flush + compaction) / user bytes.
+	// The *Count fields count output sstables, not logical runs.
+	UwalBytesWritten       uint64
+	WalBytesWritten        uint64
+	FlushBytesWritten      uint64
+	CompactionBytesWritten uint64
+	CompactionBytesRead    uint64
+	UserBytesWritten       uint64
+	FlushCount             uint64
+	CompactionCount        uint64
 }
 
 // errorFromCode converts a C error code to a GO error.
@@ -358,6 +419,8 @@ func errorFromCode(code C.int, context string) error {
 		errMsg = "database is locked"
 	case C.TDB_ERR_READONLY:
 		errMsg = "database is read-only"
+	case C.TDB_ERR_BUSY:
+		errMsg = "resource busy"
 	default:
 		errMsg = "unknown error"
 	}
@@ -388,6 +451,7 @@ func DefaultConfig() Config {
 		UnifiedMemtableSyncMode:            SyncMode(cConfig.unified_memtable_sync_mode),
 		UnifiedMemtableSyncInterval:        uint64(cConfig.unified_memtable_sync_interval_us),
 		MaxConcurrentFlushes:               int(cConfig.max_concurrent_flushes),
+		FinishCompactionsOnClose:           cConfig.finish_compactions_on_close != 0,
 	}
 }
 
@@ -409,6 +473,7 @@ func DefaultColumnFamilyConfig() ColumnFamilyConfig {
 		SyncMode:                   SyncMode(cConfig.sync_mode),
 		SyncIntervalUs:             uint64(cConfig.sync_interval_us),
 		ComparatorName:             C.GoString(&cConfig.comparator_name[0]),
+		ComparatorCtxStr:           C.GoString(&cConfig.comparator_ctx_str[0]),
 		SkipListMaxLevel:           int(cConfig.skip_list_max_level),
 		SkipListProbability:        float32(cConfig.skip_list_probability),
 		DefaultIsolationLevel:      IsolationLevel(cConfig.default_isolation_level),
@@ -420,6 +485,24 @@ func DefaultColumnFamilyConfig() ColumnFamilyConfig {
 		UseBtree:                   int(cConfig.use_btree),
 		ObjectLazyCompaction:       int(cConfig.object_lazy_compaction),
 		ObjectPrefetchCompaction:   int(cConfig.object_prefetch_compaction),
+	}
+}
+
+// setComparatorFields copies the comparator name and context string from a Go
+// ColumnFamilyConfig into the fixed-size char arrays of a C column family config,
+// NUL-terminating each. Caller-supplied strings longer than the C limits are truncated.
+func setComparatorFields(cConfig *C.tidesdb_column_family_config_t, name, ctxStr string) {
+	if name != "" {
+		cName := C.CString(name)
+		defer C.free(unsafe.Pointer(cName))
+		C.strncpy(&cConfig.comparator_name[0], cName, C.TDB_MAX_COMPARATOR_NAME-1)
+		cConfig.comparator_name[C.TDB_MAX_COMPARATOR_NAME-1] = 0
+	}
+	if ctxStr != "" {
+		cCtx := C.CString(ctxStr)
+		defer C.free(unsafe.Pointer(cCtx))
+		C.strncpy(&cConfig.comparator_ctx_str[0], cCtx, C.TDB_MAX_COMPARATOR_CTX-1)
+		cConfig.comparator_ctx_str[C.TDB_MAX_COMPARATOR_CTX-1] = 0
 	}
 }
 
@@ -453,6 +536,7 @@ func Open(config Config) (*TidesDB, error) {
 		unified_memtable_sync_mode:             C.int(config.UnifiedMemtableSyncMode),
 		unified_memtable_sync_interval_us:      C.uint64_t(config.UnifiedMemtableSyncInterval),
 		max_concurrent_flushes:                 C.int(config.MaxConcurrentFlushes),
+		finish_compactions_on_close:            C.int(0),
 	}
 
 	if config.LogToFile {
@@ -461,6 +545,10 @@ func Open(config Config) (*TidesDB, error) {
 
 	if config.UnifiedMemtable {
 		cConfig.unified_memtable = C.int(1)
+	}
+
+	if config.FinishCompactionsOnClose {
+		cConfig.finish_compactions_on_close = C.int(1)
 	}
 
 	if config.ObjectStore != nil {
@@ -580,12 +668,7 @@ func (db *TidesDB) CreateColumnFamily(name string, config ColumnFamilyConfig) er
 		cConfig.enable_block_indexes = C.int(1)
 	}
 
-	if config.ComparatorName != "" {
-		cCompName := C.CString(config.ComparatorName)
-		defer C.free(unsafe.Pointer(cCompName))
-		C.strncpy(&cConfig.comparator_name[0], cCompName, C.TDB_MAX_COMPARATOR_NAME-1)
-		cConfig.comparator_name[C.TDB_MAX_COMPARATOR_NAME-1] = 0
-	}
+	setComparatorFields(&cConfig, config.ComparatorName, config.ComparatorCtxStr)
 
 	result := C.tidesdb_create_column_family(db.db, cName, &cConfig)
 	return errorFromCode(result, "failed to create column family")
@@ -699,6 +782,14 @@ func (cf *ColumnFamily) GetStats() (*Stats, error) {
 		TombstoneRatio:     float64(cStats.tombstone_ratio),
 		MaxSSTDensity:      float64(cStats.max_sst_density),
 		MaxSSTDensityLevel: int(cStats.max_sst_density_level),
+
+		WalBytesWritten:        uint64(cStats.wal_bytes_written),
+		FlushBytesWritten:      uint64(cStats.flush_bytes_written),
+		CompactionBytesWritten: uint64(cStats.compaction_bytes_written),
+		CompactionBytesRead:    uint64(cStats.compaction_bytes_read),
+		UserBytesWritten:       uint64(cStats.user_bytes_written),
+		FlushCount:             uint64(cStats.flush_count),
+		CompactionCount:        uint64(cStats.compaction_count),
 	}
 
 	if cStats.num_levels > 0 && cStats.level_sizes != nil {
@@ -750,6 +841,7 @@ func (cf *ColumnFamily) GetStats() (*Stats, error) {
 			SyncMode:                   SyncMode(cStats.config.sync_mode),
 			SyncIntervalUs:             uint64(cStats.config.sync_interval_us),
 			ComparatorName:             C.GoString(&cStats.config.comparator_name[0]),
+			ComparatorCtxStr:           C.GoString(&cStats.config.comparator_ctx_str[0]),
 			SkipListMaxLevel:           int(cStats.config.skip_list_max_level),
 			SkipListProbability:        float32(cStats.config.skip_list_probability),
 			DefaultIsolationLevel:      IsolationLevel(cStats.config.default_isolation_level),
@@ -871,6 +963,17 @@ func (db *TidesDB) Purge() error {
 	return errorFromCode(result, "failed to purge database")
 }
 
+// CancelBackgroundWork cancels background compaction db-wide. In-flight merges
+// bail out safely and queued compaction is skipped; flushes are unaffected so
+// durability is preserved. The call blocks (bounded) until compaction is idle.
+//
+// The cancellation is sticky for the session and is reset on the next Open. It
+// is intended to be called right before Close for a fast shutdown.
+func (db *TidesDB) CancelBackgroundWork() error {
+	result := C.tidesdb_cancel_background_work(db.db)
+	return errorFromCode(result, "failed to cancel background work")
+}
+
 // GetDbStats retrieves aggregate statistics across the entire database instance.
 // Unlike GetStats (which heap-allocates), GetDbStats fills a caller-provided struct
 // on the stack. No free is needed.
@@ -903,14 +1006,14 @@ func (db *TidesDB) GetDbStats() (*DbStats, error) {
 		UnifiedIsFlushing:      cStats.unified_is_flushing != 0,
 		UnifiedNextCFIndex:     uint32(cStats.unified_next_cf_index),
 		UnifiedWalGeneration:   uint64(cStats.unified_wal_generation),
-		ObjectStoreEnabled: cStats.object_store_enabled != 0,
+		ObjectStoreEnabled:     cStats.object_store_enabled != 0,
 		ObjectStoreConnector: func() string {
 			if cStats.object_store_connector != nil {
 				return C.GoString(cStats.object_store_connector)
 			}
 			return ""
 		}(),
-		LocalCacheBytesUsed: uint64(cStats.local_cache_bytes_used),
+		LocalCacheBytesUsed:    uint64(cStats.local_cache_bytes_used),
 		LocalCacheBytesMax:     uint64(cStats.local_cache_bytes_max),
 		LocalCacheNumFiles:     int(cStats.local_cache_num_files),
 		LastUploadedGeneration: uint64(cStats.last_uploaded_generation),
@@ -918,6 +1021,15 @@ func (db *TidesDB) GetDbStats() (*DbStats, error) {
 		TotalUploads:           uint64(cStats.total_uploads),
 		TotalUploadFailures:    uint64(cStats.total_upload_failures),
 		ReplicaMode:            cStats.replica_mode != 0,
+
+		UwalBytesWritten:       uint64(cStats.uwal_bytes_written),
+		WalBytesWritten:        uint64(cStats.wal_bytes_written),
+		FlushBytesWritten:      uint64(cStats.flush_bytes_written),
+		CompactionBytesWritten: uint64(cStats.compaction_bytes_written),
+		CompactionBytesRead:    uint64(cStats.compaction_bytes_read),
+		UserBytesWritten:       uint64(cStats.user_bytes_written),
+		FlushCount:             uint64(cStats.flush_count),
+		CompactionCount:        uint64(cStats.compaction_count),
 	}, nil
 }
 
@@ -958,12 +1070,7 @@ func (cf *ColumnFamily) UpdateRuntimeConfig(config ColumnFamilyConfig, persistTo
 		cConfig.enable_block_indexes = C.int(1)
 	}
 
-	if config.ComparatorName != "" {
-		cCompName := C.CString(config.ComparatorName)
-		defer C.free(unsafe.Pointer(cCompName))
-		C.strncpy(&cConfig.comparator_name[0], cCompName, C.TDB_MAX_COMPARATOR_NAME-1)
-		cConfig.comparator_name[C.TDB_MAX_COMPARATOR_NAME-1] = 0
-	}
+	setComparatorFields(&cConfig, config.ComparatorName, config.ComparatorCtxStr)
 
 	persist := C.int(0)
 	if persistToDisk {
@@ -1298,6 +1405,7 @@ func CfConfigLoadFromIni(iniFile, sectionName string) (*ColumnFamilyConfig, erro
 		SyncMode:                   SyncMode(cConfig.sync_mode),
 		SyncIntervalUs:             uint64(cConfig.sync_interval_us),
 		ComparatorName:             C.GoString(&cConfig.comparator_name[0]),
+		ComparatorCtxStr:           C.GoString(&cConfig.comparator_ctx_str[0]),
 		SkipListMaxLevel:           int(cConfig.skip_list_max_level),
 		SkipListProbability:        float32(cConfig.skip_list_probability),
 		DefaultIsolationLevel:      IsolationLevel(cConfig.default_isolation_level),
@@ -1353,12 +1461,7 @@ func CfConfigSaveToIni(iniFile, sectionName string, config ColumnFamilyConfig) e
 		}
 	}
 
-	if config.ComparatorName != "" {
-		cCompName := C.CString(config.ComparatorName)
-		defer C.free(unsafe.Pointer(cCompName))
-		C.strncpy(&cConfig.comparator_name[0], cCompName, C.TDB_MAX_COMPARATOR_NAME-1)
-		cConfig.comparator_name[C.TDB_MAX_COMPARATOR_NAME-1] = 0
-	}
+	setComparatorFields(&cConfig, config.ComparatorName, config.ComparatorCtxStr)
 
 	result := C.tidesdb_cf_config_save_to_ini(cIniFile, cSectionName, &cConfig)
 	return errorFromCode(result, "failed to save config to INI")

--- a/tidesdb_test.go
+++ b/tidesdb_test.go
@@ -18,6 +18,7 @@ package tidesdb_go
 
 import (
 	"bytes"
+	"encoding/binary"
 	"encoding/gob"
 	"fmt"
 	"os"
@@ -4186,5 +4187,370 @@ func TestMaxConcurrentFlushesConfig(t *testing.T) {
 
 	if err := cf.FlushMemtable(); err != nil {
 		t.Fatalf("FlushMemtable failed: %v", err)
+	}
+}
+
+func TestRaiseOpenFileLimit(t *testing.T) {
+	// A non-positive request reports the current ceiling without changing it.
+	current := RaiseOpenFileLimit(0)
+	if current <= 0 {
+		t.Fatalf("Expected a positive current open-file ceiling, got %d", current)
+	}
+	t.Logf("Current open-file ceiling: %d", current)
+
+	// Requesting the current ceiling should report at least that many.
+	after := RaiseOpenFileLimit(current)
+	if after < current {
+		t.Fatalf("Ceiling shrank after raise attempt: before=%d after=%d", current, after)
+	}
+	t.Logf("Open-file ceiling after raise(%d): %d", current, after)
+}
+
+func TestCancelBackgroundWork(t *testing.T) {
+	cleanupTestDB(t)
+	defer cleanupTestDB(t)
+
+	config := DefaultConfig()
+	config.DBPath = "testdb"
+
+	db, err := Open(config)
+	if err != nil {
+		t.Fatalf("Failed to open database: %v", err)
+	}
+	defer db.Close()
+
+	cfConfig := DefaultColumnFamilyConfig()
+	if err := db.CreateColumnFamily("cancel_cf", cfConfig); err != nil {
+		t.Fatalf("Failed to create column family: %v", err)
+	}
+	cf, err := db.GetColumnFamily("cancel_cf")
+	if err != nil {
+		t.Fatalf("Failed to get column family: %v", err)
+	}
+
+	// Write some data so there is potential background work.
+	for i := 0; i < 100; i++ {
+		txn, err := db.BeginTxn()
+		if err != nil {
+			t.Fatalf("Failed to begin txn: %v", err)
+		}
+		key := []byte(fmt.Sprintf("key-%04d", i))
+		if err := txn.Put(cf, key, bytes.Repeat([]byte("v"), 128), -1); err != nil {
+			t.Fatalf("Put failed: %v", err)
+		}
+		if err := txn.Commit(); err != nil {
+			t.Fatalf("Commit failed: %v", err)
+		}
+		txn.Free()
+	}
+
+	if err := db.CancelBackgroundWork(); err != nil {
+		t.Fatalf("CancelBackgroundWork failed: %v", err)
+	}
+	t.Logf("CancelBackgroundWork completed successfully")
+}
+
+func TestFinishCompactionsOnCloseConfig(t *testing.T) {
+	cleanupTestDB(t)
+	defer cleanupTestDB(t)
+
+	defaults := DefaultConfig()
+	t.Logf("Default FinishCompactionsOnClose: %t", defaults.FinishCompactionsOnClose)
+
+	config := defaults
+	config.DBPath = "testdb"
+	config.FinishCompactionsOnClose = true
+
+	db, err := Open(config)
+	if err != nil {
+		t.Fatalf("Failed to open database with FinishCompactionsOnClose=true: %v", err)
+	}
+
+	cfConfig := DefaultColumnFamilyConfig()
+	if err := db.CreateColumnFamily("finish_cf", cfConfig); err != nil {
+		t.Fatalf("Failed to create column family: %v", err)
+	}
+	cf, err := db.GetColumnFamily("finish_cf")
+	if err != nil {
+		t.Fatalf("Failed to get column family: %v", err)
+	}
+
+	txn, err := db.BeginTxn()
+	if err != nil {
+		t.Fatalf("Failed to begin txn: %v", err)
+	}
+	if err := txn.Put(cf, []byte("k"), []byte("v"), -1); err != nil {
+		t.Fatalf("Put failed: %v", err)
+	}
+	if err := txn.Commit(); err != nil {
+		t.Fatalf("Commit failed: %v", err)
+	}
+	txn.Free()
+
+	// Close should honor the finish-compactions-on-close behavior without error.
+	if err := db.Close(); err != nil {
+		t.Fatalf("Failed to close database: %v", err)
+	}
+}
+
+func TestErrorCodeBusy(t *testing.T) {
+	if ErrBusy != -14 {
+		t.Fatalf("Expected ErrBusy to be -14, got %d", ErrBusy)
+	}
+	t.Logf("ErrBusy = %d", ErrBusy)
+}
+
+func TestBuiltinComparatorNames(t *testing.T) {
+	cases := map[string]string{
+		ComparatorMemcmp:          "memcmp",
+		ComparatorLexicographic:   "lexicographic",
+		ComparatorUint64:          "uint64",
+		ComparatorInt64:           "int64",
+		ComparatorReverse:         "reverse",
+		ComparatorCaseInsensitive: "case_insensitive",
+	}
+	for got, want := range cases {
+		if got != want {
+			t.Fatalf("Built-in comparator name mismatch: got %q want %q", got, want)
+		}
+	}
+}
+
+func TestUint64ComparatorOrdering(t *testing.T) {
+	cleanupTestDB(t)
+	defer cleanupTestDB(t)
+
+	config := DefaultConfig()
+	config.DBPath = "testdb"
+
+	db, err := Open(config)
+	if err != nil {
+		t.Fatalf("Failed to open database: %v", err)
+	}
+	defer db.Close()
+
+	cfConfig := DefaultColumnFamilyConfig()
+	cfConfig.ComparatorName = ComparatorUint64
+	if err := db.CreateColumnFamily("u64_cf", cfConfig); err != nil {
+		t.Fatalf("Failed to create column family: %v", err)
+	}
+	cf, err := db.GetColumnFamily("u64_cf")
+	if err != nil {
+		t.Fatalf("Failed to get column family: %v", err)
+	}
+
+	// The uint64 comparator reads each 8-byte key in host byte order, so encode
+	// keys with NativeEndian. Insert out of numeric order.
+	nums := []uint64{5, 1, 256, 3, 2, 1000, 4}
+	for _, n := range nums {
+		key := make([]byte, 8)
+		binary.NativeEndian.PutUint64(key, n)
+		txn, err := db.BeginTxn()
+		if err != nil {
+			t.Fatalf("Failed to begin txn: %v", err)
+		}
+		if err := txn.Put(cf, key, []byte("v"), -1); err != nil {
+			t.Fatalf("Put failed: %v", err)
+		}
+		if err := txn.Commit(); err != nil {
+			t.Fatalf("Commit failed: %v", err)
+		}
+		txn.Free()
+	}
+
+	// Verify the cf config round-trips the comparator name.
+	stats, err := cf.GetStats()
+	if err != nil {
+		t.Fatalf("GetStats failed: %v", err)
+	}
+	if stats.Config == nil || stats.Config.ComparatorName != ComparatorUint64 {
+		t.Fatalf("Expected ComparatorName %q in stats config, got %+v", ComparatorUint64, stats.Config)
+	}
+
+	// Iterate forward; keys must come out in ascending numeric order.
+	txn, err := db.BeginTxn()
+	if err != nil {
+		t.Fatalf("Failed to begin txn: %v", err)
+	}
+	defer txn.Free()
+	iter, err := txn.NewIterator(cf)
+	if err != nil {
+		t.Fatalf("Failed to create iterator: %v", err)
+	}
+	defer iter.Free()
+
+	if err := iter.SeekToFirst(); err != nil {
+		t.Fatalf("SeekToFirst failed: %v", err)
+	}
+
+	var got []uint64
+	for iter.Valid() {
+		key, err := iter.Key()
+		if err != nil {
+			t.Fatalf("Key failed: %v", err)
+		}
+		if len(key) != 8 {
+			t.Fatalf("Expected 8-byte key, got %d bytes", len(key))
+		}
+		got = append(got, binary.NativeEndian.Uint64(key))
+		if err := iter.Next(); err != nil {
+			break
+		}
+	}
+
+	want := []uint64{1, 2, 3, 4, 5, 256, 1000}
+	if len(got) != len(want) {
+		t.Fatalf("Expected %d keys, got %d: %v", len(want), len(got), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("uint64 comparator ordering wrong at %d: got %v want %v", i, got, want)
+		}
+	}
+	t.Logf("uint64 comparator produced ascending order: %v", got)
+}
+
+func TestComparatorCtxStrIni(t *testing.T) {
+	iniFile := "testdb_comparator_ctx.ini"
+	os.Remove(iniFile)
+	defer os.Remove(iniFile)
+
+	config := DefaultColumnFamilyConfig()
+	config.Name = "ctx_cf"
+	config.ComparatorName = ComparatorMemcmp
+	config.ComparatorCtxStr = "endian=big;width=8"
+
+	if err := CfConfigSaveToIni(iniFile, "ctx_cf", config); err != nil {
+		t.Fatalf("Failed to save config to INI: %v", err)
+	}
+
+	loaded, err := CfConfigLoadFromIni(iniFile, "ctx_cf")
+	if err != nil {
+		t.Fatalf("Failed to load config from INI: %v", err)
+	}
+
+	if loaded.ComparatorName != config.ComparatorName {
+		t.Fatalf("ComparatorName mismatch: got %q want %q", loaded.ComparatorName, config.ComparatorName)
+	}
+	if loaded.ComparatorCtxStr != config.ComparatorCtxStr {
+		t.Fatalf("ComparatorCtxStr mismatch: got %q want %q", loaded.ComparatorCtxStr, config.ComparatorCtxStr)
+	}
+	t.Logf("Round-tripped ComparatorCtxStr: %q", loaded.ComparatorCtxStr)
+}
+
+func TestStatsWriteAmplification(t *testing.T) {
+	cleanupTestDB(t)
+	defer cleanupTestDB(t)
+
+	config := DefaultConfig()
+	config.DBPath = "testdb"
+
+	db, err := Open(config)
+	if err != nil {
+		t.Fatalf("Failed to open database: %v", err)
+	}
+	defer db.Close()
+
+	cfConfig := DefaultColumnFamilyConfig()
+	if err := db.CreateColumnFamily("wa_cf", cfConfig); err != nil {
+		t.Fatalf("Failed to create column family: %v", err)
+	}
+	cf, err := db.GetColumnFamily("wa_cf")
+	if err != nil {
+		t.Fatalf("Failed to get column family: %v", err)
+	}
+
+	for i := 0; i < 200; i++ {
+		txn, err := db.BeginTxn()
+		if err != nil {
+			t.Fatalf("Failed to begin txn: %v", err)
+		}
+		key := []byte(fmt.Sprintf("wa-key-%05d", i))
+		if err := txn.Put(cf, key, bytes.Repeat([]byte("x"), 256), -1); err != nil {
+			t.Fatalf("Put failed: %v", err)
+		}
+		if err := txn.Commit(); err != nil {
+			t.Fatalf("Commit failed: %v", err)
+		}
+		txn.Free()
+	}
+
+	if err := cf.FlushMemtable(); err != nil {
+		t.Fatalf("FlushMemtable failed: %v", err)
+	}
+	// Block until flush settles so flush counters are populated.
+	if err := cf.PurgeCF(); err != nil {
+		t.Fatalf("PurgeCF failed: %v", err)
+	}
+
+	stats, err := cf.GetStats()
+	if err != nil {
+		t.Fatalf("GetStats failed: %v", err)
+	}
+
+	t.Logf("WA counters: user=%d wal=%d flush=%d(%d files) compaction_w=%d compaction_r=%d(%d outs)",
+		stats.UserBytesWritten, stats.WalBytesWritten, stats.FlushBytesWritten, stats.FlushCount,
+		stats.CompactionBytesWritten, stats.CompactionBytesRead, stats.CompactionCount)
+
+	if stats.UserBytesWritten == 0 {
+		t.Fatalf("Expected UserBytesWritten > 0 after committing data")
+	}
+	if stats.FlushBytesWritten == 0 {
+		t.Fatalf("Expected FlushBytesWritten > 0 after flush+purge")
+	}
+}
+
+func TestDbStatsWriteAmplification(t *testing.T) {
+	cleanupTestDB(t)
+	defer cleanupTestDB(t)
+
+	config := DefaultConfig()
+	config.DBPath = "testdb"
+
+	db, err := Open(config)
+	if err != nil {
+		t.Fatalf("Failed to open database: %v", err)
+	}
+	defer db.Close()
+
+	cfConfig := DefaultColumnFamilyConfig()
+	if err := db.CreateColumnFamily("dbwa_cf", cfConfig); err != nil {
+		t.Fatalf("Failed to create column family: %v", err)
+	}
+	cf, err := db.GetColumnFamily("dbwa_cf")
+	if err != nil {
+		t.Fatalf("Failed to get column family: %v", err)
+	}
+
+	for i := 0; i < 100; i++ {
+		txn, err := db.BeginTxn()
+		if err != nil {
+			t.Fatalf("Failed to begin txn: %v", err)
+		}
+		key := []byte(fmt.Sprintf("dbwa-%05d", i))
+		if err := txn.Put(cf, key, bytes.Repeat([]byte("y"), 200), -1); err != nil {
+			t.Fatalf("Put failed: %v", err)
+		}
+		if err := txn.Commit(); err != nil {
+			t.Fatalf("Commit failed: %v", err)
+		}
+		txn.Free()
+	}
+
+	if err := db.Purge(); err != nil {
+		t.Fatalf("Purge failed: %v", err)
+	}
+
+	stats, err := db.GetDbStats()
+	if err != nil {
+		t.Fatalf("GetDbStats failed: %v", err)
+	}
+
+	t.Logf("DB WA counters: user=%d uwal=%d wal=%d flush=%d compaction_w=%d compaction_r=%d flush_count=%d compaction_count=%d",
+		stats.UserBytesWritten, stats.UwalBytesWritten, stats.WalBytesWritten, stats.FlushBytesWritten,
+		stats.CompactionBytesWritten, stats.CompactionBytesRead, stats.FlushCount, stats.CompactionCount)
+
+	if stats.UserBytesWritten == 0 {
+		t.Fatalf("Expected db-wide UserBytesWritten > 0 after committing data")
 	}
 }


### PR DESCRIPTION
bind the remaining functions and struct fields exposed by db.h that the go binding was missing

new functions
raiseopenfilelimit wraps tidesdb_raise_open_file_limit cancelbackgroundwork wraps tidesdb_cancel_background_work objstores3create and objstores3createconfig wrap the s3 connector factories behind the tidesdb_s3 build tag since the optional s3 symbols are not present unless the c library is built with s3 on

new constants
errbusy for tdb_err_busy
comparator name constants for the six builtin comparators that the engine auto registers at open time

config additions
finishcompactionsonclose on config wired through defaultconfig and open comparatorctxstr on columnfamilyconfig wired through create update and the ini load and save paths

stats additions
write amplification counters on stats and dbstats wal flush and compaction byte and count fields

note the uint64 and int64 builtin comparators read keys in host byte order so tests and docs use native endian encoding

add tests for every new binding and extend the go reference docs

all tests pass and clean under the race detector vet and gofmt